### PR TITLE
Bidirectional typechecking

### DIFF
--- a/examples/good/unannotated_lambda.arvo
+++ b/examples/good/unannotated_lambda.arvo
@@ -1,0 +1,1 @@
+def Id : Type -> Type := \T. T.

--- a/normalize.c
+++ b/normalize.c
@@ -38,7 +38,7 @@ static term* normalize_fuel_app(context *Sigma, typing_context* Delta, term* t, 
 term* normalize_fuel_lambda(context *Sigma, typing_context* Delta, term* t, int fuel) {
   term* b = NULL;
   term* A = normalize_fuel(Sigma, Delta, t->left, fuel-1);
-  if (!A) goto error;
+
   context* extend = context_add(variable_dup(t->var), NULL, Sigma);
   b = normalize_fuel(extend, Delta, t->right, fuel-1);
   context_pop(extend);
@@ -125,7 +125,7 @@ term* normalize_fuel_var(context *Sigma, typing_context* Delta, term* t, int fue
 }
 
 term* normalize_fuel(context *Sigma, typing_context* Delta, term* t, int fuel) {
-  check(t, "t must be non-NULL");
+  if (t == NULL) return NULL;
   check(term_locally_well_formed(t), "t must be locally well formed");
   check(fuel >= 0, "Stack depth exceeded")
 

--- a/parser.c
+++ b/parser.c
@@ -51,10 +51,16 @@ term* ast_to_term(mpc_ast_t* ast) {
   } else if (strstr(ast->tag, "type")) {
     return make_type();
   } else if (prefix("lambda", ast->tag)) {
-    check(ast->children_num == 6, "malformed lambda node");
-    return make_lambda(make_variable(strdup(ast->children[1]->contents)),
-                       ast_to_term(ast->children[3]),
-                       ast_to_term(ast->children[5]));
+    if (ast->children_num == 4) {
+      return make_lambda(make_variable(strdup(ast->children[1]->contents)),
+                         NULL,
+                         ast_to_term(ast->children[3]));
+    } else {
+      check(ast->children_num == 6, "malformed lambda node");
+      return make_lambda(make_variable(strdup(ast->children[1]->contents)),
+                         ast_to_term(ast->children[3]),
+                         ast_to_term(ast->children[5]));
+    }
   } else if (prefix("pi", ast->tag)) {
     if (ast->children[0]->contents[0] == '(') {
       check(ast->children_num == 7, "malformed pi node");
@@ -207,7 +213,7 @@ parsing_context* parse(char* filename) {
               " comment : /@[^@]*@/                              ; \n"
               " var     : /[a-zA-Z][a-zA-Z0-9_]*/ ;                \n"
               " bound   : \"_\" | <var> ;                          \n"
-              " lambda  : \"\\\\\" <bound> ':' <term> '.' <term> ; \n"
+              " lambda  : \"\\\\\" <bound> (':' <term>)? '.' <term> ; \n"
               " pi      : '(' <bound> ':' <term> ')' \"->\" <term> \n"
               "         |  <app> \"->\" <term> ; \n"
               " base    : <type> | <var> | '(' <term> ')' ; \n"

--- a/parser.c
+++ b/parser.c
@@ -129,9 +129,14 @@ command *ast_to_command(mpc_ast_t *ast) {
     return make_print(make_variable(strdup(ast->children[1]->contents)));
   }
   else if (prefix("check", ast->tag)) {
-    check(ast->children_num == 3, "malformed check");
-
-    return make_check(ast_to_term(ast->children[1]));
+    if (ast->children_num == 3) {
+      return make_check(ast_to_term(ast->children[1]));
+    } else {
+      check(ast->children_num == 5, "malformed check");
+      command* ans = make_check(ast_to_term(ast->children[1]));
+      ans->right = ast_to_term(ast->children[3]);
+      return ans;
+    }
   }
   else if (prefix("simpl", ast->tag)) {
     check(ast->children_num == 3, "malformed simpl");
@@ -224,7 +229,7 @@ parsing_context* parse(char* filename) {
               " axiom   : \"axiom\" <var> ':' <term> '.' ;\n"
               " import  : \"import\" <var> '.' ;\n"
               " print   : \"print\" <var> '.' ;\n"
-              " check   : \"check\" <term> '.' ;\n"
+              " check   : \"check\" <term> (':' <term>)? '.' ;\n"
               " simpl   : \"simpl\" <term> '.' ;\n"
               " constructor : <var> (':' <term>)? ;\n"
               " data    : \"data\" <var> \":=\" <constructor>? ('|' <constructor>)* '.' ;\n"

--- a/stdlib/axiomatic_equality.arvo
+++ b/stdlib/axiomatic_equality.arvo
@@ -15,21 +15,21 @@ axiom J : (A : Type) -> (P : (a : A) -> (b : A) -> eq A a b -> Type) -> (a : A) 
 check J.
 
 def eq_sym : (A : Type) -> (a : A) -> (b : A) -> eq A a b -> eq A b a :=
-    \A : Type. \a : A. \b : A. \pf : eq A a b.
-    subst A (\x : A. eq A x a) a (refl A a) b pf.
+    \A. \a. \b. \pf.
+    subst A (\x. eq A x a) a (refl A a) b pf.
 check eq_sym.
 print eq_sym.
 
 def eq_trans : (A : Type) -> (a : A) -> (b : A) -> (c : A) -> eq A a b -> eq A b c -> eq A a c :=
-    \A : Type. \a : A. \b : A. \c : A.
-      \ab : eq A a b.
-        subst A (\x : A. eq A x c -> eq A a c) a (\y : eq A a c. y) b ab.
+    \A. \a. \b. \c.
+      \ab.
+        subst A (\x. eq A x c -> eq A a c) a (\y. y) b ab.
 check eq_trans.
 print eq_trans.
 
 def f_equal : (A : Type) -> (B : Type) -> (f : A -> B) -> (x : A) -> (y : A) ->
               eq A x y -> eq B (f x) (f y) :=
-  \A : Type. \B : Type. \f : A -> B. \x : A. \y : A. \H : eq A x y.
-    subst A (\z : A. eq B (f x) (f z)) x (refl B (f x)) y H.
+  \A. \B. \f. \x. \y. \H.
+    subst A (\z. eq B (f x) (f z)) x (refl B (f x)) y H.
 check f_equal.
 print f_equal.

--- a/stdlib/nat.arvo
+++ b/stdlib/nat.arvo
@@ -3,8 +3,8 @@ import axiomatic_equality.
 data nat := O | S : nat -> nat.
 
 def plus : nat -> nat -> nat :=
-    \ n : nat. \m : nat.
-      nat_elim (\_ : nat. nat) m (\_ : nat. \y : nat. S y) n.
+    \n. \m.
+      nat_elim (\_. nat) m (\_. \y. S y) n.
 
 check (\n : nat. plus O n).
 simpl (\n : nat. plus O n).
@@ -14,7 +14,7 @@ check ((n : nat) -> eq nat (plus O n) O).
 simpl ((n : nat) -> eq nat (plus O n) O).
 
 def plus_O_n : (n : nat) -> eq nat (plus O n) n :=
-    \n : nat. refl nat n.
+    \n. refl nat n.
 
 check subst.
 
@@ -23,6 +23,8 @@ axiom admit : (A : Type) -> A.
 check nat_elim.
 
 def plus_n_O : (n : nat) -> eq nat (plus n O) n :=
-     \n : nat. nat_elim (\x : nat. eq nat (plus x O) x) (refl nat O)
-                        (\x : nat. \IH : eq nat (plus x O) x.
-                           f_equal nat nat S (plus x O) x IH) n.
+     \n. nat_elim (\x. eq nat (plus x O) x)
+                  (refl nat O)
+                  (\x. \IH. f_equal nat nat S (plus x O) x IH)
+                  n.
+

--- a/stdlib/nat.arvo
+++ b/stdlib/nat.arvo
@@ -28,3 +28,21 @@ def plus_n_O : (n : nat) -> eq nat (plus n O) n :=
                   (\x. \IH. f_equal nat nat S (plus x O) x IH)
                   n.
 
+def plus_n_S : (n : nat) -> (m : nat) -> eq nat (plus n (S m)) (S (plus n m)) :=
+    \n. \m.
+        nat_elim (\x. eq nat (plus x (S m)) (S (plus x m)))
+                 (refl nat (S m))
+                 (\x. \IH : eq nat (plus x (S m)) (S (plus x m)).
+                   f_equal nat nat S (plus x (S m)) (S (plus x m)) IH)
+                 n.
+
+def plus_comm : (n : nat) -> (m : nat) -> eq nat (plus n m) (plus m n) :=
+    \n. nat_elim (\x. (m : nat) -> eq nat (plus x m) (plus m x))
+                 (\m. eq_sym nat (plus m O) (plus O m) (plus_n_O m))
+                 (\x. \IH.
+                     \m. eq_trans nat (plus (S x) m) (S (plus m x)) (plus m (S x))
+                                  (f_equal nat nat S (plus x m) (plus m x) (IH m))
+                                  (eq_sym nat (plus m (S x)) (S (plus m x))
+                                          (plus_n_S m x)))
+                 n.
+

--- a/typecheck.c
+++ b/typecheck.c
@@ -86,10 +86,13 @@ int typecheck_check(telescope* Gamma, context *Sigma, typing_context* Delta, ter
       if (variable_equal(t->var, &ignore)) {
         return typecheck_check(Gamma, Sigma, Delta, t->right, ty->right);
       }
-      term* tvar = make_var(t->var);
+      term* tvar = make_var(variable_dup(t->var));
       Gamma = telescope_add(variable_dup(t->var), substitute(ty->var, tvar, ty->left), Gamma);
-      int ans = typecheck_check(Gamma, Sigma, Delta, t->right, substitute(ty->var, tvar, ty->right));
+      term* codomain = substitute(ty->var, tvar, ty->right);
+      int ans = typecheck_check(Gamma, Sigma, Delta, t->right, codomain);
       telescope_pop(Gamma);
+      free_term(tvar);
+      free_term(codomain);
       return ans;
     }
   default:

--- a/typecheck.c
+++ b/typecheck.c
@@ -12,11 +12,9 @@ static term* typecheck_app(telescope* Gamma, context* Sigma, typing_context* Del
   check(tyFun->tag == PI, "Function %W has type %W but expected to have pi-type",
         fun, print_term, tyFun, print_term);
 
-  tyArg = typecheck(Gamma, Sigma, Delta, arg);
-  check(tyArg != NULL, "Bad argument %W", arg, print_term);
-  check(definitionally_equal(Sigma, Delta, tyFun->left, tyArg),
-        "Type mismatch in function application: function has domain %W but argument has type %W",
-        tyFun->left, print_term, tyArg, print_term);
+  check(typecheck_check(Gamma, Sigma, Delta, arg, tyFun->left),
+        "Type mismatch in function application: argument expected to have type %W",
+        tyFun->left, print_term);
 
   term* ans = substitute(tyFun->var, arg, tyFun->right);
 
@@ -75,12 +73,41 @@ static term* typecheck_pi(telescope* Gamma, context* Sigma, typing_context* Delt
   return NULL;
 }
 
+int typecheck_check(telescope* Gamma, context *Sigma, typing_context* Delta, term* t, term* ty) {
+  check(t, "term must be non-NULL");
+  check(term_locally_well_formed(t), "term must be well formed");
+  check(ty, "type must be non-NULL");
+  check(term_locally_well_formed(ty), "type must be well formed");
 
+  switch (t->tag) {
+  case LAM:
+    if (t->left == NULL) {
+      check(ty->tag == PI, "checking lambda against non-pi %W", ty, print_term);
+      if (variable_equal(t->var, &ignore)) {
+        return typecheck_check(Gamma, Sigma, Delta, t->right, ty->right);
+      }
+      term* tvar = make_var(t->var);
+      Gamma = telescope_add(variable_dup(t->var), substitute(ty->var, tvar, ty->left), Gamma);
+      int ans = typecheck_check(Gamma, Sigma, Delta, t->right, substitute(ty->var, tvar, ty->right));
+      telescope_pop(Gamma);
+      return ans;
+    }
+  default:
+    {
+      term* inferred = typecheck_infer(Gamma, Sigma, Delta, t);
+      int ans = definitionally_equal(Sigma, Delta, ty, inferred);
+      if (!ans)
+        log_err("in context %W\n%W expected to have type %W but has type %W", Gamma, print_telescope, t, print_term, ty, print_term, inferred, print_term);
+      free_term(inferred);
+      return ans;
+    }
+  }
 
-/*
-  Caller should free result.
- */
-term* typecheck(telescope* Gamma, context *Sigma, typing_context* Delta, term* t) {
+ error:
+  return 0;
+}
+
+term* typecheck_infer(telescope* Gamma, context *Sigma, typing_context* Delta, term* t) {
   check(t, "term must be non-NULL");
   check(term_locally_well_formed(t), "term must be well formed");
 
@@ -92,6 +119,7 @@ term* typecheck(telescope* Gamma, context *Sigma, typing_context* Delta, term* t
       return term_dup(ty);
     }
   case LAM:
+    check(t->left != NULL, "Cannot infer type ");
     return typecheck_lam(Gamma, Sigma, Delta, t->var, t->left, t->right);
   case PI:
     return typecheck_pi(Gamma, Sigma, Delta, t->var, t->left, t->right);
@@ -106,6 +134,7 @@ term* typecheck(telescope* Gamma, context *Sigma, typing_context* Delta, term* t
  error:
   return NULL;
 }
+
 
 int has_type(telescope *Gamma, context *Sigma, typing_context* Delta, term *t, term *ty) {
   term* tty = typecheck(Gamma, Sigma, Delta, t);

--- a/typecheck.h
+++ b/typecheck.h
@@ -6,6 +6,11 @@
 #include "context.h"
 #include "typing_context.h"
 
-term* typecheck(telescope* Gamma, context *Sigma, typing_context* Delta, term* t);
+int typecheck_check(telescope* Gamma, context *Sigma, typing_context* Delta, term* t, term* ty);
+
+term* typecheck_infer(telescope* Gamma, context *Sigma, typing_context* Delta, term* t);
+
+#define typecheck(G,S,D,t) typecheck_infer(G,S,D,t)
+
 int has_type(telescope *Gamma, context *Sigma, typing_context* Delta, term *t, term *ty);
 #endif  // TYPECHECK_H

--- a/vernac.c
+++ b/vernac.c
@@ -37,29 +37,21 @@ int print_command(FILE* stream, command* c) {
 }
 
 static void vernac_run_def(command* c) {
-  term* ty = NULL;
-  term* kind = typecheck(Gamma, Sigma, Delta, c->left);
   term* Type = make_type();
-  check(definitionally_equal(Sigma, Delta, kind, Type), "%W is not well typed.", c->left, print_term);
+  check(typecheck_check(Gamma, Sigma, Delta, c->left, Type), "%W is not well typed.", c->left, print_term);
   free_term(Type);
   Type = NULL;
-  free_term(kind);
-  kind = NULL;
 
-  ty = typecheck(Gamma, Sigma, Delta, c->right);
-  check(definitionally_equal(Sigma, Delta, ty, c->left), "Term %W\n has type %W\n instead of %W",
+  check(typecheck_check(Gamma, Sigma, Delta, c->right, c->left), "Term %W\n failed to have type %W\n",
         c->right, print_term,
-        ty, print_term,
         c->left, print_term);
-  free_term(ty);
+
 
   Gamma = telescope_add(variable_dup(c->var), term_dup(c->left), Gamma);
   Sigma = context_add(variable_dup(c->var), term_dup(c->right), Sigma);
   printf("%W defined\n", c->var, print_variable);
   return;
  error:
-  free_term(ty);
-  free_term(kind);
   free_term(Type);
 }
 

--- a/vernac.c
+++ b/vernac.c
@@ -65,9 +65,15 @@ void vernac_run(command *c) {
     break;
   case CHECK:
     {
-      term* ty = typecheck(Gamma, Sigma, Delta, c->left);
-      printf("%W : %W\n", c->left, print_term, ty, print_term);
-      free_term(ty);
+      if (c->right == NULL) {
+        term* ty = typecheck(Gamma, Sigma, Delta, c->left);
+        printf("%W : %W\n", c->left, print_term, ty, print_term);
+        free_term(ty);
+      } else {
+        check(typecheck_check(Gamma, Sigma, Delta, c->right, make_type()), "RHS of check is ill-typed");
+        check(typecheck_check(Gamma, Sigma, Delta, c->left, c->right), "Check failed.");
+        printf("check succeeded.\n");
+      }
       break;
     }
   case SIMPL:


### PR DESCRIPTION
This branch implements bidirectional type checking. Concretely, that means you can leave off lambda annotations whenever it is obvious from the context above you.

Lambdas without an annotation are represented by setting their left pointer to NULL. This was probably a bad choice in retrospect, since it ends up being very difficult to distinguish error cases from empty annotations. 
