### PR TITLE
Holes

### DIFF
--- a/examples/good/holes.arvo
+++ b/examples/good/holes.arvo
@@ -1,0 +1,1 @@
+check (\x : Type . ? ) : Type -> Type.

--- a/parser.c
+++ b/parser.c
@@ -174,6 +174,7 @@ command *ast_to_command(mpc_ast_t *ast) {
 
 static mpc_parser_t* pComment;
 static mpc_parser_t* pVar;
+static mpc_parser_t* pHole;
 static mpc_parser_t* pBound;
 static mpc_parser_t* pLambda;
 static mpc_parser_t* pPi;
@@ -195,6 +196,7 @@ static mpc_parser_t* pProgram;
 parsing_context* parse(char* filename) {
   pComment = mpc_new("comment");
   pVar = mpc_new("var");
+  pHole = mpc_new("hole");
   pBound = mpc_new("bound");
   pLambda = mpc_new("lambda");
   pPi = mpc_new("pi");
@@ -217,11 +219,12 @@ parsing_context* parse(char* filename) {
     mpca_lang(MPCA_LANG_DEFAULT,
               " comment : /@[^@]*@/                              ; \n"
               " var     : /[a-zA-Z][a-zA-Z0-9_]*/ ;                \n"
+              " hole    : \"\?\" ; \n"
               " bound   : \"_\" | <var> ;                          \n"
               " lambda  : \"\\\\\" <bound> (':' <term>)? '.' <term> ; \n"
               " pi      : '(' <bound> ':' <term> ')' \"->\" <term> \n"
               "         |  <app> \"->\" <term> ; \n"
-              " base    : <type> | <var> | '(' <term> ')' ; \n"
+              " base    : <type> | <hole> | <var> | '(' <term> ')' ; \n"
               " app     : <base> <base>* ;\n"
               " type    : \"Type\" ;\n"
               " term    : <lambda> | <pi> | <app>;\n"
@@ -235,7 +238,7 @@ parsing_context* parse(char* filename) {
               " data    : \"data\" <var> \":=\" <constructor>? ('|' <constructor>)* '.' ;\n"
               " command : <def> | <print> | <check> | <simpl> | <data> | <axiom> | <import> | <comment>;\n"
               " program  : /^/ <command> * /$/ ;\n",
-              pComment, pVar, pBound, pLambda, pPi, pBase, pApp, pType,
+              pComment, pVar, pHole, pBound, pLambda, pPi, pBase, pApp, pType,
               pTerm,
               pDef, pAxiom, pImport, pPrint, pCheck, pSimpl, pConstructor, pData, pCommand, pProgram, NULL);
 
@@ -253,14 +256,14 @@ parsing_context* parse(char* filename) {
     mpc_err_delete(ans->result.error);
     goto error;
   }
-  mpc_cleanup(19, pComment, pVar, pBound, pLambda, pPi, pApp, pBase, pType,
+  mpc_cleanup(20, pComment, pVar, pHole, pBound, pLambda, pPi, pApp, pBase, pType,
               pTerm, pCommand, pDef, pAxiom, pImport, pPrint, pCheck, pSimpl,
               pConstructor, pData, pProgram);
   //mpc_ast_print(ans->result.output);
   ans->command_index = 1;
   return ans;
  error:
-  mpc_cleanup(19, pComment, pVar, pBound, pLambda, pPi, pApp, pBase, pType,
+  mpc_cleanup(20, pComment, pVar, pHole, pBound, pLambda, pPi, pApp, pBase, pType,
               pTerm, pCommand, pDef, pAxiom, pImport, pPrint, pCheck, pSimpl,
               pConstructor, pData, pProgram);
   return NULL;

--- a/parser.c
+++ b/parser.c
@@ -50,6 +50,8 @@ term* ast_to_term(mpc_ast_t* ast) {
     return make_var(make_variable(strdup(ast->contents)));
   } else if (strstr(ast->tag, "type")) {
     return make_type();
+  } else if (strstr(ast->tag, "hole")) {
+    return make_hole();
   } else if (prefix("lambda", ast->tag)) {
     if (ast->children_num == 4) {
       return make_lambda(make_variable(strdup(ast->children[1]->contents)),

--- a/stdlib/nat.arvo
+++ b/stdlib/nat.arvo
@@ -46,3 +46,9 @@ def plus_comm : (n : nat) -> (m : nat) -> eq nat (plus n m) (plus m n) :=
                                           (plus_n_S m x)))
                  n.
 
+def plus_assoc : (a : nat) -> (b : nat) -> (c : nat) -> eq nat (plus (plus a b) c) (plus a (plus b c)) :=
+    \a. \b. \c.
+      nat_elim (\x. eq nat (plus (plus x b) c) (plus x (plus b c)))
+               (refl nat (plus b c))
+               (\x. \IH. f_equal nat nat S (plus (plus x b) c) (plus x (plus b c)) IH)
+               a.

--- a/term.c
+++ b/term.c
@@ -14,6 +14,8 @@ int print_term(FILE* stream, term* t) {
   switch (t->tag) {
   case VAR:
     return print_variable(stream, t->var);
+  case HOLE:
+    return fprintf(stream, "<hole>");
   case LAM:
     if (t->left == NULL) {
       return fprintf(stream, "\\%W. %W", t->var, print_variable, t->right, print_term);
@@ -103,6 +105,13 @@ term* make_pi(variable* x, term* A, term* B) {
 term* make_type() {
   term* ans = make_term();
   ans->tag = TYPE;
+
+  return ans;
+}
+
+term* make_hole() {
+  term* ans = make_term();
+  ans->tag = HOLE;
 
   return ans;
 }
@@ -244,6 +253,8 @@ int is_free(variable *var, term *haystack) {
     if (variable_equal(var, haystack->var)) {
       return 1;
     }
+    return 0;
+  case HOLE:
     return 0;
   case LAM:
   case PI:
@@ -399,6 +410,7 @@ int term_locally_well_formed(term* t) {
   case INTRO:
   case ELIM:
   case DATATYPE:
+  case HOLE:
     return 1;
 
   default:

--- a/term.h
+++ b/term.h
@@ -24,7 +24,8 @@ typedef enum {
   TYPE,
   INTRO,
   ELIM,
-  DATATYPE
+  DATATYPE,
+  HOLE
 } term_tag;
 
 
@@ -65,6 +66,7 @@ term* make_app(term* a, term* b);
 term* make_var(variable* var);
 
 term* make_type();
+term* make_hole();
 
 term* make_intro(variable* name, int num_args);
 term* make_elim(variable* name, int num_args);

--- a/typecheck.c
+++ b/typecheck.c
@@ -93,7 +93,9 @@ int typecheck_check(telescope* Gamma, context *Sigma, typing_context* Delta, ter
               t->left, print_term, nty->left, print_term);
       }
       if (variable_equal(t->var, &ignore)) {
-        return typecheck_check(Gamma, Sigma, Delta, t->right, nty->right);
+        int ans = typecheck_check(Gamma, Sigma, Delta, t->right, nty->right);
+        free_term(nty);
+        return ans;
       }
       term* tvar = make_var(variable_dup(t->var));
       Gamma = telescope_add(variable_dup(t->var), substitute(nty->var, tvar, nty->left), Gamma);

--- a/typecheck.c
+++ b/typecheck.c
@@ -80,19 +80,30 @@ int typecheck_check(telescope* Gamma, context *Sigma, typing_context* Delta, ter
   check(term_locally_well_formed(ty), "type must be well formed");
 
   switch (t->tag) {
+  case HOLE:
+    log_info("Hole has type %W", ty, print_term);
+    return 1;
   case LAM:
-    if (t->left == NULL) {
-      check(ty->tag == PI, "checking lambda against non-pi %W", ty, print_term);
+    {
+      term* nty = normalize(Sigma, Delta, ty);
+      check(nty->tag == PI, "checking lambda term %W against non-pi %W", t, print_term, nty, print_term);
+      if (t->left != NULL) {
+        check(definitionally_equal(Sigma, Delta, t->left, nty->left),
+              "annotation %W does not match type %W",
+              t->left, print_term, nty->left, print_term);
+      }
       if (variable_equal(t->var, &ignore)) {
-        return typecheck_check(Gamma, Sigma, Delta, t->right, ty->right);
+        return typecheck_check(Gamma, Sigma, Delta, t->right, nty->right);
       }
       term* tvar = make_var(variable_dup(t->var));
-      Gamma = telescope_add(variable_dup(t->var), substitute(ty->var, tvar, ty->left), Gamma);
-      term* codomain = substitute(ty->var, tvar, ty->right);
+      Gamma = telescope_add(variable_dup(t->var), substitute(nty->var, tvar, nty->left), Gamma);
+      term* codomain = substitute(nty->var, tvar, nty->right);
+
       int ans = typecheck_check(Gamma, Sigma, Delta, t->right, codomain);
       telescope_pop(Gamma);
       free_term(tvar);
       free_term(codomain);
+      free_term(nty);
       return ans;
     }
   default:
@@ -130,6 +141,8 @@ term* typecheck_infer(telescope* Gamma, context *Sigma, typing_context* Delta, t
     return typecheck_app(Gamma, Sigma, Delta, t->left, t->right);
   case TYPE:
     return make_type();
+  case HOLE:
+    sentinel("Cannot infer type of hole.");
   default:
     sentinel("Bad tag %d", t->tag);
   }

--- a/vernac.c
+++ b/vernac.c
@@ -55,6 +55,24 @@ static void vernac_run_def(command* c) {
   free_term(Type);
 }
 
+static void vernac_run_check(command* c) {
+  term* Type = NULL;
+  if (c->right == NULL) {
+    term* ty = typecheck(Gamma, Sigma, Delta, c->left);
+    printf("%W : %W\n", c->left, print_term, ty, print_term);
+    free_term(ty);
+  } else {
+    Type = make_type();
+    check(typecheck_check(Gamma, Sigma, Delta, c->right, Type), "RHS of check is ill-typed");
+    check(typecheck_check(Gamma, Sigma, Delta, c->left, c->right), "Check failed.");
+    printf("check succeeded.\n");
+    free_term(Type);
+  }
+  return;
+ error:
+  free_term(Type);
+}
+
 void vernac_run(command *c) {
   switch (c->tag) {
   case DEF:
@@ -64,18 +82,8 @@ void vernac_run(command *c) {
     printf("%W\n", context_lookup(c->var, Sigma), print_term);
     break;
   case CHECK:
-    {
-      if (c->right == NULL) {
-        term* ty = typecheck(Gamma, Sigma, Delta, c->left);
-        printf("%W : %W\n", c->left, print_term, ty, print_term);
-        free_term(ty);
-      } else {
-        check(typecheck_check(Gamma, Sigma, Delta, c->right, make_type()), "RHS of check is ill-typed");
-        check(typecheck_check(Gamma, Sigma, Delta, c->left, c->right), "Check failed.");
-        printf("check succeeded.\n");
-      }
-      break;
-    }
+    vernac_run_check(c);
+    break;
   case SIMPL:
     {
       term* t = normalize(Sigma, Delta, c->left);


### PR DESCRIPTION
You can put a hole anywhere in a term that its type can be inferred. Arvo will tell you the type of the hole. This is really nice for iterative development of proofs.

The concrete syntax is a question mark. From examples/good/holes.arvo:

```
check (\x : Type . ? ) : Type -> Type.
```

Arvo responds that the hole has type Type.
