### PR TITLE
Bind multiple variables in concrete Pi expression

### DIFF
--- a/examples/good/multipi.arvo
+++ b/examples/good/multipi.arvo
@@ -1,0 +1,6 @@
+axiom eq : (A : Type) -> A -> A -> Type.
+
+data nat := O | S : nat -> nat.
+
+def comm : (f : nat -> nat -> nat) -> Type :=
+  \f. (n m : nat) -> eq _ (f n m) (f m n).

--- a/stdlib/axiomatic_equality.arvo
+++ b/stdlib/axiomatic_equality.arvo
@@ -16,13 +16,13 @@ axiom J : (A : Type) -> (P : (a : A) -> (b : A) -> eq _ a b -> Type) ->
 check J.
 
 
-def eq_sym : (A : Type) -> (a : A) -> (b : A) -> eq _ a b -> eq _ b a :=
+def eq_sym : (A : Type) -> (a b : A) -> eq _ a b -> eq _ b a :=
     \A : Type. \a : A. \b : A. \pf : eq A a b.
      subst A (\x : A. eq A x a) a (refl A a) b pf.
 check eq_sym.
 print eq_sym.
 
-def eq_trans : (A : Type) -> (a : A) -> (b : A) -> (c : A) ->
+def eq_trans : (A : Type) -> (a b c : A) ->
                eq _ a b -> eq _ b c -> eq _ a c :=
     \A. \a. \b. \c.
       \ab.
@@ -30,7 +30,7 @@ def eq_trans : (A : Type) -> (a : A) -> (b : A) -> (c : A) ->
 check eq_trans.
 print eq_trans.
 
-def f_equal : (A : Type) -> (B : Type) -> (f : A -> B) -> (x : A) -> (y : A) ->
+def f_equal : (A B : Type) -> (f : A -> B) -> (x y : A) ->
               eq A x y -> eq B (f x) (f y) :=
   \A. \B. \f. \x. \y. \H.
     subst A (\z. eq B (f x) (f z)) x (refl B (f x)) y H.
@@ -42,10 +42,10 @@ def rewrite : (A : Type) -> (P : A -> Type) -> (a : A) -> P a -> (b : A) ->
   \A. \P. \a. \pa. \b. \Heq.
     subst A P a pa b (eq_sym _ _ _ Heq).
 
-def f_equal2 : (A : Type) -> (B : Type) -> (C : Type) ->
+def f_equal2 : (A B C : Type) ->
                (f : A -> B -> C) ->
-               (a1 : A) -> (a2 : A) -> eq _ a1 a2 ->
-               (b1 : B) -> (b2 : B) -> eq _ b1 b2 ->
+               (a1 a2 : A) -> eq _ a1 a2 ->
+               (b1 b2 : B) -> eq _ b1 b2 ->
                eq _ (f a1 b1) (f a2 b2) :=
   \A. \B. \C.
   \f.

--- a/stdlib/bool.arvo
+++ b/stdlib/bool.arvo
@@ -45,7 +45,7 @@ def eqb_bool : bool -> bool -> bool :=
     if _ x y (notb y).
 
 
-def eqb_bool_sound : (x : bool) -> (y : bool) -> eq _ (eqb_bool x y) true -> eq _ x y :=
+def eqb_bool_sound : (x y : bool) -> eq _ (eqb_bool x y) true -> eq _ x y :=
   \x. \y.
     bool_elim (\z. eq _ (eqb_bool z y) true -> eq _ z y)
               (\H. eq_sym _ _ _ H)

--- a/stdlib/nat.arvo
+++ b/stdlib/nat.arvo
@@ -29,7 +29,7 @@ def plus_n_O : (n : nat) -> eq _ (plus n O) n :=
                   (\x. \IH : eq _ (plus x O) x. f_equal _ _ S _ _ IH)
                   n.
 
-def plus_n_S : (n : nat) -> (m : nat) -> eq _ (plus n (S m)) (S (plus n m)) :=
+def plus_n_S : (n m : nat) -> eq _ (plus n (S m)) (S (plus n m)) :=
     \n. \m.
         nat_elim (\x. eq _ (plus x (S m)) (S (plus x m)))
                  (refl _ (S m))
@@ -37,7 +37,7 @@ def plus_n_S : (n : nat) -> (m : nat) -> eq _ (plus n (S m)) (S (plus n m)) :=
                    f_equal _ _ S _ _ IH)
                  n.
 
-def plus_comm : (n : nat) -> (m : nat) -> eq nat (plus n m) (plus m n) :=
+def plus_comm : (n m : nat) -> eq nat (plus n m) (plus m n) :=
     \n. nat_elim (\x. (m : nat) -> eq _ (plus x m) (plus m x))
                  (\m. eq_sym _ _ _ (plus_n_O m))
                  (\x. \IH : (m : nat) -> eq _ (plus x m) (plus m x).
@@ -46,7 +46,7 @@ def plus_comm : (n : nat) -> (m : nat) -> eq nat (plus n m) (plus m n) :=
                                   (eq_sym _ _ _ (plus_n_S m x)))
                  n.
 
-def plus_assoc : (a : nat) -> (b : nat) -> (c : nat) ->
+def plus_assoc : (a b c : nat) ->
                  eq _ (plus (plus a b) c) (plus a (plus b c)) :=
     \a. \b. \c.
       nat_elim (\x. eq _ (plus (plus x b) c) (plus x (plus b c)))
@@ -64,7 +64,7 @@ def mult_n_O : (n : nat) -> eq _ (mult n O) O :=
                (\x. \IH. IH)
                n.
 
-def lemma : (a : nat) -> (b : nat) -> (c : nat) ->
+def lemma : (a b c : nat) ->
              eq _ (plus a (plus b c))
                   (plus b (plus a c)) :=
   \a. \b. \c.
@@ -81,7 +81,7 @@ def lemma : (a : nat) -> (b : nat) -> (c : nat) ->
           (plus_assoc a b c).
 
 
-def mult_n_S : (n : nat) -> (m : nat) -> eq _ (mult n (S m)) (plus n (mult n m)) :=
+def mult_n_S : (n m : nat) -> eq _ (mult n (S m)) (plus n (mult n m)) :=
   \n. \m.
      nat_elim (\x. eq _ (mult x (S m)) (plus x (mult x m)))
      	      (refl _ O)
@@ -95,7 +95,7 @@ def mult_n_S : (n : nat) -> (m : nat) -> eq _ (mult n (S m)) (plus n (mult n m))
                              IH))
 	      n.
 
-def mult_comm : (n : nat) -> (m : nat) -> eq _ (mult n m) (mult m n) :=
+def mult_comm : (n m : nat) -> eq _ (mult n m) (mult m n) :=
   \n. \m.
     nat_elim (\x. eq _ (mult x m) (mult m x))
              (eq_sym _ _ _ (mult_n_O _))
@@ -108,7 +108,7 @@ def mult_comm : (n : nat) -> (m : nat) -> eq _ (mult n m) (mult m n) :=
                        (mult_n_S m x))
              n.
 
-def mult_plus_dist_r : (a : nat) -> (b : nat) -> (c : nat) -> eq _ (mult (plus a b) c) (plus (mult a c) (mult b c)) :=
+def mult_plus_dist_r : (a b c : nat) -> eq _ (mult (plus a b) c) (plus (mult a c) (mult b c)) :=
   \a. \b. \c.
     nat_elim (\x. eq _ (mult (plus x b) c) (plus (mult x c) (mult b c)))
              (refl _ _)
@@ -122,7 +122,7 @@ def mult_plus_dist_r : (a : nat) -> (b : nat) -> (c : nat) -> eq _ (mult (plus a
              a.
 
 
-def mult_assoc : (a : nat) -> (b : nat) -> (c : nat) -> eq _ (mult (mult a b) c) (mult a (mult b c)) :=
+def mult_assoc : (a b c : nat) -> eq _ (mult (mult a b) c) (mult a (mult b c)) :=
   \a. \b. \c.
     nat_elim (\x. eq _ (mult (mult x b) c) (mult x (mult b c)))
              (refl _ _)
@@ -165,7 +165,7 @@ def eqb_nat_refl : (n : nat) -> eq _ (eqb_nat n n) true :=
              (\_. \IH. IH)
              n.
 
-def eqb_nat_sound : (n : nat) -> (m : nat) -> eq _ (eqb_nat n m) true -> eq _ n m :=
+def eqb_nat_sound : (n m : nat) -> eq _ (eqb_nat n m) true -> eq _ n m :=
   \n.
     nat_elim (\z. (m : nat) -> eq _ (eqb_nat z m) true -> eq _ z m)
              (\m. nat_case (\z. eq _ (nat_case_simple _ true (\_. false) z) true -> eq _ O z)

--- a/stdlib/nat.arvo
+++ b/stdlib/nat.arvo
@@ -145,6 +145,12 @@ def nat_case : (P : nat -> Type) -> P O -> ((n : nat) -> P (S n)) -> (n : nat) -
 def nat_case_simple : (A : Type) -> A -> ((n : nat) -> A) -> (n : nat) -> A :=
   \A. nat_case (\_. A).
 
+def nat_rec : (A : Type) -> A -> (A -> A) -> (n : nat) -> A :=
+  \A. \o. \s.
+    nat_elim (\_. A)
+             o
+             (\_. s).
+
 def eqb_nat : nat -> nat -> bool :=
   \n.
     nat_elim (\_. nat -> bool)

--- a/stdlib/reassoc.arvo
+++ b/stdlib/reassoc.arvo
@@ -28,7 +28,7 @@ check (\a. \b. \c. refl _ (normalize_local (Plus (Plus a b) c))) :
            (expr_case_simple _ (\n. Plus (Atom n) (normalize_local c))
                         (\ll. \lr. Plus ll (Plus lr (normalize_local c))) (normalize_local (Plus a b))).
 
-def expr_case : (P : expr -> Type) -> ((n : nat) -> P (Atom n)) -> ((l : expr) -> (r : expr) -> P (Plus l r)) -> (e : expr) -> P e :=
+def expr_case : (P : expr -> Type) -> ((n : nat) -> P (Atom n)) -> ((l r : expr) -> P (Plus l r)) -> (e : expr) -> P e :=
   \P. \a. \f. expr_elim P a (\l. \_. \r. \_. f l r).
 
 
@@ -99,8 +99,7 @@ def eval_uncollect :
         l.
 
 def sum_append :
-  (l : nonempty_natlist) ->
-  (r : nonempty_natlist) ->
+  (l r : nonempty_natlist) ->
     eq _ (sum (append l r)) (plus (sum l) (sum r)) :=
   \l. \r.
     nonempty_natlist_elim (\z. eq _ (sum (append z r)) (plus (sum z) (sum r)))
@@ -146,7 +145,7 @@ simpl (\a. \b. \c.
               (Plus (Plus (Atom b) (Atom a)) (Plus (Atom c) (Atom c))))).
 
 def example :
-    (a : nat) -> (b : nat) -> (c : nat) ->
+    (a b c : nat) ->
     eq _ (plus (plus (plus a b) (plus c c))
                (plus (plus b a) (plus c c)))
          (plus a (plus b (plus c (plus c


### PR DESCRIPTION
For example, `(n m : nat) -> Type` now parses as `(n : nat) -> (m : nat) -> Type`. This PR also ports the stdlib to use this new syntax where possible. 

This PR depends on #5. Its base should be changed to master after #5 is merged.
