### PR TITLE
Rust FFI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: c
+language: rust
+rust:
+  - 1.2.0
 script: bash -ex .travis-ci.sh
 addons:
   apt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "arvo"
+version = "0.1.0"
+authors = ["jrw"]
+[dependencies]
+libc = "*"
+[lib]
+name = "arvo"
+crate-type = ["staticlib"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ clean :
 	rm -rf arvo
 
 arvo: main.c term.c typecheck.c telescope.c parser.c printing.c vernac.c context.c typing_context.c normalize.c  mpc/mpc.c dbg.c
-	gcc -Wall -Wextra -Wno-format -g main.c term.c typecheck.c telescope.c parser.c vernac.c context.c typing_context.c normalize.c mpc/mpc.c printing.c dbg.c -o arvo -lm
+	gcc -Wall -Wextra -Wno-format -g main.c term.c typecheck.c telescope.c parser.c vernac.c context.c typing_context.c normalize.c mpc/mpc.c printing.c dbg.c ./target/debug/libarvo.a -o arvo -lm 
 
 .PHONY : default clean

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ default: arvo
 clean :
 	rm -rf arvo
 
-arvo: main.c term.c typecheck.c telescope.c parser.c printing.c vernac.c context.c typing_context.c normalize.c  mpc/mpc.c dbg.c
-	gcc -Wall -Wextra -Wno-format -g main.c term.c typecheck.c telescope.c parser.c vernac.c context.c typing_context.c normalize.c mpc/mpc.c printing.c dbg.c ./target/debug/libarvo.a -o arvo -lm 
+arvo: main.c term.c typecheck.c telescope.c parser.c printing.c vernac.c context.c typing_context.c normalize.c  mpc/mpc.c dbg.c target/debug/libarvo.a
+	gcc -Wall -Wextra -Wno-format -g -pthread main.c term.c typecheck.c telescope.c parser.c vernac.c context.c typing_context.c normalize.c mpc/mpc.c printing.c dbg.c ./target/debug/libarvo.a -o arvo -lm -ldl -lrt
+
+target/debug/libarvo.a: src/ffi.rs src/lib.rs src/prettyprint.rs src/term.rs
+	cargo build
 
 .PHONY : default clean

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -95,7 +95,7 @@ pub unsafe fn cterm_to_term(t: *mut term) -> Box<Term> {
     )
 }
 
-fn string_to_cstring(s: &String) -> *mut libc::c_char {
+pub fn string_to_cstring(s: &String) -> *mut libc::c_char {
     unsafe { 
         strdup(CString::new(s.clone()).unwrap().as_ptr())
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,145 @@
+use libc;
+use term::Term;
+use term::Term::*;
+use term::Variable;
+use std::ffi::{CStr, CString};
+use std::str;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+enum term_tag {
+  VAR,
+  LAM,
+  PI, 
+  APP,
+  TYPE,
+  INTRO,
+  ELIM,
+  DATATYPE,
+  HOLE
+}
+
+#[repr(C)]
+struct variable {
+    name: *mut libc::c_char
+}
+
+#[repr(C)]
+pub struct term {
+    tag: term_tag,
+    var: *mut variable,
+    left: *mut term,
+    right: *mut term,
+    
+    num_args: libc::c_int,
+    args: *mut *mut term
+}
+
+extern "C" {
+    fn strdup(s: *const libc::c_char) -> *mut libc::c_char;
+
+    fn make_variable(name: *mut libc::c_char) -> *mut variable;
+
+    fn make_pi(x: *mut variable, A: *mut term, B: *mut term) -> *mut term;
+    fn make_lambda(x: *mut variable, a: *mut term, B: *mut term) -> *mut term;
+    fn make_app(a: *mut term, b: *mut term) -> *mut term;
+    fn make_var(a: *mut variable) -> *mut term;
+    fn make_type() -> *mut term;
+    fn make_hole() -> *mut term;
+    fn make_intro(name: *mut variable, ty: *mut term, num_args: libc::c_int) -> *mut term;
+    fn make_elim(name: *mut variable, num_args: libc::c_int) -> *mut term;
+    fn make_datatype_term(name: *mut variable) -> *mut term;
+}
+
+unsafe fn charstar_to_string(s: *const libc::c_char) -> String {
+    let bytes = CStr::from_ptr(s).to_bytes(); 
+    str::from_utf8(bytes).unwrap().to_owned()
+}
+
+unsafe fn cvar_to_var(v: *const variable) -> Variable {
+    Variable { name: charstar_to_string((*v).name) }
+}
+
+unsafe fn carray_to_vec_term(n: libc::c_int, a: *mut *mut term) -> Vec<Term> {
+    let mut ans = Vec::with_capacity(n as usize);
+    for i in 0..n {
+        ans.push(*cterm_to_term(*a.offset(i as isize)));
+    }
+    ans
+}
+
+
+pub unsafe fn cterm_to_term(t: *mut term) -> Box<Term> {
+    use self::term_tag::*;
+    Box::new(
+        match (*t).tag {
+            TYPE => Type,
+            HOLE => Hole,
+            VAR => Var(cvar_to_var((*t).var)),
+            LAM => Lambda(cvar_to_var((*t).var), 
+                          cterm_to_term((*t).left), 
+                          cterm_to_term((*t).right)),
+            PI => Pi(cvar_to_var((*t).var),
+                     cterm_to_term((*t).left), 
+                     cterm_to_term((*t).right)),
+            APP => App(cterm_to_term((*t).left), 
+                       cterm_to_term((*t).right)),
+            INTRO => Intro(cvar_to_var((*t).var),
+                           cterm_to_term((*t).left),
+                           carray_to_vec_term((*t).num_args, (*t).args)),
+            ELIM => Elim(cvar_to_var((*t).var),
+                         carray_to_vec_term((*t).num_args, (*t).args)),
+            DATATYPE => Data(cvar_to_var((*t).var)),
+        }
+    )
+}
+
+fn string_to_cstring(s: &String) -> *mut libc::c_char {
+    unsafe { 
+        strdup(CString::new(s.clone()).unwrap().as_ptr())
+    }
+}
+
+fn var_to_cvar(x: &Variable) -> *mut variable {
+    unsafe { 
+        make_variable(string_to_cstring(&x.name))
+    }
+}
+
+unsafe fn fill_out_carray(dest: *mut *mut term, src: &Vec<Term>) {
+    for (i, t) in src.iter().enumerate() {
+        *dest.offset(i as isize) = term_to_cterm(t);
+    }
+}
+
+pub fn term_to_cterm(t: &Term) -> *mut term {
+    unsafe {
+        match *t {
+            Type => make_type(),
+            Hole => make_hole(),
+            Var(ref name) => make_var(var_to_cvar(name)),
+            Lambda(ref x, ref a, ref b) => make_lambda(var_to_cvar(x),
+                                                       term_to_cterm(a), 
+                                                       term_to_cterm(b)),
+            Pi(ref x, ref a, ref b) => make_pi(var_to_cvar(x),
+                                               term_to_cterm(a), 
+                                               term_to_cterm(b)),
+            App(ref a, ref b) => make_app(term_to_cterm(a), 
+                                          term_to_cterm(b)),
+            Intro(ref name, ref a, ref v) => {
+                let t = make_intro(var_to_cvar(name), 
+                                   term_to_cterm(a),
+                                   v.len() as libc::c_int);
+                fill_out_carray((*t).args, v);
+                t
+            },
+            Elim(ref name, ref v) => {
+                let t = make_elim(var_to_cvar(name), 
+                                  v.len() as libc::c_int);
+                fill_out_carray((*t).args, v);
+                t
+            },
+            Data(ref name) => make_datatype_term(var_to_cvar(name)),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ mod prettyprint;
 
 #[no_mangle]
 pub extern "C" fn C_prettyprint(t: *mut ffi::term) -> *const libc::c_char{
+    if t.is_null() {
+        return ffi::string_to_cstring(&"NULL".to_string())
+    }
     let rt = unsafe { ffi::cterm_to_term(t) }; 
     let s = prettyprint::prettyprint(&*rt);
     ffi::string_to_cstring(&s)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+#![crate_type = "staticlib"]
+extern crate libc;
+mod term;
+mod ffi;
+
+#[no_mangle]
+pub extern "C" fn rust_test(t: *mut ffi::term) -> *mut ffi::term {
+    let rt = unsafe { ffi::cterm_to_term(t) }; 
+    println!("{:?}", rt);
+    ffi::term_to_cterm(&rt)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,11 @@
 extern crate libc;
 mod term;
 mod ffi;
+mod prettyprint;
 
 #[no_mangle]
-pub extern "C" fn rust_test(t: *mut ffi::term) -> *mut ffi::term {
+pub extern "C" fn C_prettyprint(t: *mut ffi::term) -> *const libc::c_char{
     let rt = unsafe { ffi::cterm_to_term(t) }; 
-    println!("{:?}", rt);
-    ffi::term_to_cterm(&rt)
+    let s = prettyprint::prettyprint(&*rt);
+    ffi::string_to_cstring(&s)
 }

--- a/src/prettyprint.rs
+++ b/src/prettyprint.rs
@@ -1,0 +1,111 @@
+use term::Term;
+use term::Term::*;
+
+#[derive(Clone,Copy,Eq,PartialEq,PartialOrd,Ord,Debug)]
+enum Prec {
+    BOT,
+    APP,
+    LAM,
+    TOP,
+}
+
+use prettyprint::Prec::*;
+
+#[derive(Clone,Copy,Eq,PartialEq,PartialOrd,Ord)]
+enum Side {
+    LEFT,
+    RIGHT,
+    NONE
+}
+
+use prettyprint::Side::*;
+
+pub fn prettyprint(t: &Term) -> String {
+    let mut buf = String::new();
+    go(&mut buf, t, Prec::TOP, NONE);
+    buf
+}
+
+fn term_prec(t: &Term) -> Prec {
+    match *t {
+        Lambda(_,_,_) => LAM,
+        Pi(_,_,_) => LAM,
+        App(_,_) => APP,
+        _ => BOT
+    }
+}
+
+fn prec_assoc(p: Prec) -> Side {
+    match p {
+        LAM => RIGHT,
+        APP => LEFT,
+        TOP => NONE,
+        BOT => NONE
+    }
+}
+
+fn no_parens(ip: Prec, op: Prec, s: Side) -> bool {
+    ip < op || (ip == op && s == prec_assoc(ip))
+}
+
+fn go(buf: &mut String, t: &Term, p: Prec, s: Side) {
+    if (!no_parens(term_prec(t), p, s)) {
+        buf.push_str("(");
+        go(buf, t, TOP, NONE);
+        buf.push_str(")");
+        return;
+    }
+    match *t {
+        Type => buf.push_str("Type"),
+        Hole => buf.push_str("?"),
+        Var(ref v) => buf.push_str(&v.name),
+        Lambda(ref v, ref a, ref b) => {
+            buf.push_str("\\");
+            buf.push_str(&v.name);
+            match *a {
+                Some(ref ty) => {
+                    buf.push_str(" : ");
+                    go(buf, ty, Prec::TOP, NONE)
+                }
+                None => {}
+            }
+            buf.push_str(". ");
+            go(buf, b, LAM, RIGHT)
+        }
+        Pi(ref v, ref a, ref b) => {
+            if v.name != "_" {
+                buf.push_str("(");
+                buf.push_str(&v.name);
+                buf.push_str(" : ");
+                go(buf, a, TOP, NONE);
+                buf.push_str(")");
+            } else {
+                go(buf, a, LAM, LEFT);
+            }
+            buf.push_str(" -> ");
+            go(buf, b, LAM, RIGHT);
+
+        }
+        App(ref l, ref r) => {
+            go(buf, l, APP, LEFT);
+            buf.push_str(" ");
+            go(buf, r, APP, RIGHT);
+        }
+
+        Data(ref v) => buf.push_str(&v.name),
+        Intro(ref v, _, ref args) |
+        Elim (ref v,    ref args) => {
+            buf.push_str(&v.name);
+            buf.push_str("(");
+            let mut started = false;
+            for arg in args {
+                if started {
+                    buf.push_str("; ");
+                }
+                started = true;
+                go(buf, arg, TOP, NONE);
+            }
+            buf.push_str(")");
+        }
+    }
+}

--- a/src/term.rs
+++ b/src/term.rs
@@ -8,7 +8,7 @@ pub enum Term {
     Type, 
     Hole,
     Var(Variable),
-    Lambda(Variable, Box<Term>, Box<Term>),
+    Lambda(Variable, Option<Box<Term>>, Box<Term>),
     Pi(Variable, Box<Term>, Box<Term>),
     App(Box<Term>, Box<Term>),
     Intro(Variable, Box<Term>, Vec<Term>),

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,0 +1,17 @@
+#[derive(Debug)]
+pub struct Variable {
+    pub name: String
+}
+
+#[derive(Debug)]
+pub enum Term {
+    Type, 
+    Hole,
+    Var(Variable),
+    Lambda(Variable, Box<Term>, Box<Term>),
+    Pi(Variable, Box<Term>, Box<Term>),
+    App(Box<Term>, Box<Term>),
+    Intro(Variable, Box<Term>, Vec<Term>),
+    Elim(Variable, Vec<Term>),
+    Data(Variable)
+}

--- a/term.c
+++ b/term.c
@@ -11,77 +11,13 @@ int print_variable(FILE* stream, variable* v) {
   return fprintf(stream, "%s", v->name);
 }
 
-int print_term(FILE* stream, term* t) {
-  if (t == NULL) return fprintf(stream, "NULL");
+extern char* C_prettyprint(term* t);
 
-  switch (t->tag) {
-  case VAR:
-    return print_variable(stream, t->var);
-  case HOLE:
-    return fprintf(stream, "<hole>");
-  case IMPLICIT:
-    if (t->right == NULL) {
-      return fprintf(stream, "<implicit>");
-    } else {
-      return fprintf(stream, "%W", t->right, print_term);
-    }
-  case LAM:
-    if (t->left == NULL) {
-      return fprintf(stream, "\\%W. %W", t->var, print_variable, t->right, print_term);
-    } else {
-      return fprintf(stream, "\\%W : %W. %W", t->var, print_variable, t->left, print_term, t->right, print_term);
-    }
-  case PI:
-    if (variable_equal(t->var, &ignore)) {
-      return fprintf(stream, "(%W -> %W)", t->left, print_term, t->right, print_term);
-    } else {
-      return fprintf(stream, "((%W : %W) -> %W)", t->var, print_variable, t->left, print_term, t->right, print_term);
-    }
-  case APP:
-    return fprintf(stream, "(%W %W)", t->left, print_term, t->right, print_term);
-  case TYPE:
-    return fprintf(stream, "Type");
-  case INTRO:
-    {
-      int total = 0;
-      total += fprintf(stream, "%W", t->var, print_variable);
-      if (t->num_args) {
-        total += fprintf(stream, "(");
-        int i;
-        for (i = 0; i < t->num_args; i++) {
-          if (i) {
-            total += fprintf(stream, "; ");
-          }
-          total += fprintf(stream, "%W", t->args[i], print_term);
-        }
-        total += fprintf(stream, ")");
-      }
-      return total;
-    }
-    return fprintf(stream, "%W", t->var, print_variable);
-  case ELIM:
-    {
-      int total = 0;
-      total += fprintf(stream, "%W", t->var, print_variable);
-      total += fprintf(stream, "(");
-      int i;
-      for (i = 0; i < t->num_args; i++) {
-        if (i) {
-          total += fprintf(stream, "; ");
-        }
-        total += fprintf(stream, "%W", t->args[i], print_term);
-      }
-      total += fprintf(stream, ")");
-      return total;
-    }
-  case DATATYPE:
-    return fprintf(stream, "%W", t->var, print_variable);
-  default:
-    sentinel("Bad tag %d", t->tag);
-  }
-    
- error:
-  return -1;
+int print_term(FILE* stream, term* t) {
+  char* s = C_prettyprint(t);
+  int ans = fprintf(stream, "%s", s);
+  free(s);
+  return ans;
 }
 
 int print_term_and_free(FILE* stream, term* t) {

--- a/vernac.c
+++ b/vernac.c
@@ -22,8 +22,6 @@ void vernac_init(char* working_directory) {
   wd = strdup(working_directory);
 }
 
-term* rust_test(term* t);
-
 int print_command(FILE* stream, command* c) {
   if (c == NULL) return fprintf(stream, "NULL");
 
@@ -272,12 +270,8 @@ void vernac_run(command *c) {
     vernac_run_def(c);
     break;
   case PRINT:
-    {
-      term* ans = rust_test(context_lookup(c->var, Sigma));
-      printf("ans = %W\n", ans, print_term);
-      //printf("%W\n", context_lookup(c->var, Sigma), print_term);
-      break;
-    }
+    printf("%W\n", context_lookup(c->var, Sigma), print_term);
+    break;
   case CHECK:
     vernac_run_check(c);
     break;

--- a/vernac.c
+++ b/vernac.c
@@ -22,6 +22,8 @@ void vernac_init(char* working_directory) {
   wd = strdup(working_directory);
 }
 
+term* rust_test(term* t);
+
 int print_command(FILE* stream, command* c) {
   if (c == NULL) return fprintf(stream, "NULL");
 
@@ -270,8 +272,12 @@ void vernac_run(command *c) {
     vernac_run_def(c);
     break;
   case PRINT:
-    printf("%W\n", context_lookup(c->var, Sigma), print_term);
-    break;
+    {
+      term* ans = rust_test(context_lookup(c->var, Sigma));
+      printf("ans = %W\n", ans, print_term);
+      //printf("%W\n", context_lookup(c->var, Sigma), print_term);
+      break;
+    }
   case CHECK:
     vernac_run_check(c);
     break;


### PR DESCRIPTION
This PR adds support for manipulating Arvo terms in Rust. As an example, I implemented a (much) better pretty printer, which we can call from the C side to get nicely parenthesized terms. 
