### PR TITLE
Add emacs mode feature to admit a hole.

### DIFF
--- a/arvo-mode.el
+++ b/arvo-mode.el
@@ -69,4 +69,21 @@
   (set (make-local-variable 'font-lock-defaults) '(arvo-font-lock-keywords))
   (font-lock-fontify-buffer))
 
+(defun arvo-get-type-of-hole ()
+  (interactive)
+  (call-process (concat (getenv "ARVO_HOME") "/get-type-of-hole.sh")
+                (buffer-file-name)
+                t))
+
+(defun arvo-insert-admit-for-hole-at-point ()
+  (interactive)
+  (if (not (eq (char-after (point)) ??))
+      (error "Point is not on hole.")
+    (progn
+      (delete-char 1)
+      (insert "(admit (")
+      (arvo-get-type-of-hole)
+      (insert "))"))))
+
+
 (provide 'arvo-mode)

--- a/get-type-of-hole.sh
+++ b/get-type-of-hole.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$ARVO_HOME/arvo $1 2>&1 | grep "Hole has type" | head -n1 | cut -d' ' -f9- | tr -d '\n'


### PR DESCRIPTION
When point is hovering over the first hole in an arvo buffer, M-x arvo-insert-admit-for-hole-at-point will insert an admit for the type of that hole. Works via hacky shell stuff. Only works for first hole in buffer. Still damn useful for avoiding copying from terminal.
