### PR TITLE
Incremental parsing

### DIFF
--- a/main.c
+++ b/main.c
@@ -12,17 +12,23 @@
 
 int main(int argc, char **argv) {
   setup_printing();
+  initialize_arvo_parsers();
 
-  check(argc > 1, "Need a filename.");
+  int ans = 0;
 
-  char* filename = strdup(argv[1]);
-  vernac_init(dirname(filename));
-  free(filename);
-  filename = NULL;
+  if (argc > 1) {
+    char* filename = strdup(argv[1]);
+    vernac_init(dirname(filename));
+    free(filename);
+    filename = NULL;
 
-  int ans = process_file(argv[1]);
+    ans = process_file(argv[1]);
+  } else {
+    vernac_init(".");
+    ans = process_stream("standard input", stdin);
+  }
+
+  cleanup_arvo_parsers();
 
   return ans;
- error:
-  return 1;
 }

--- a/parser.c
+++ b/parser.c
@@ -310,6 +310,7 @@ command *next_command(parsing_context* pc) {
       mpc_err_delete(pc->result.error);
       return NULL;
     }
+    mpc_ast_delete(pc->result.output);
   }
 
   if (feof(pc->stream)) return NULL;
@@ -330,7 +331,9 @@ command *next_command(parsing_context* pc) {
 
   //mpc_ast_print(ast);
 
-  return ast_to_command(ast->children[1]);
+  command* ans = ast_to_command(ast->children[1]);
+  mpc_ast_delete(ast);
+  return ans;
  error:
   return NULL;
 }

--- a/parser.c
+++ b/parser.c
@@ -322,7 +322,7 @@ command *next_command(parsing_context* pc) {
       return NULL;
     }
     ast = (mpc_ast_t *)(pc->result.output);
-  } while (strstr(ast->tag, "comment"));
+  } while (strstr(ast->children[1]->tag, "comment"));
 
   pc->expect_sep = 1;
 

--- a/parser.h
+++ b/parser.h
@@ -6,9 +6,12 @@
 
 typedef struct parsing_context parsing_context;
 
-parsing_context* parse(char* filename);
+void initialize_arvo_parsers();
+void cleanup_arvo_parsers();
+
+parsing_context* make_parsing_context(char* filename, FILE* stream);
+void free_parsing_context(parsing_context* pc);
 
 command *next_command(parsing_context* pc);
-void free_parsing_context(parsing_context* pc);
 
 #endif  // PARSER_H

--- a/vernac.c
+++ b/vernac.c
@@ -525,13 +525,13 @@ command *make_import(variable* name) {
   return ans;
 }
 
-int process_file(char* filename) {
+
+int process_stream(char* filename, FILE* stream) {
   command *c;
 
-  parsing_context* pc = parse(filename);
-  check(pc, "Parse error");
+  parsing_context* pc = make_parsing_context(filename, stream);
 
-  while((c = next_command(pc))) {
+  while(!feof(stream) && (c = next_command(pc))) {
     vernac_run(c);
     free_command(c);
   }
@@ -539,8 +539,11 @@ int process_file(char* filename) {
   free_parsing_context(pc);
 
   return 0;
-
- error:
-  return 1;
 }
 
+int process_file(char* filename) {
+  FILE* stream = fopen(filename, "r");
+  int ans = process_stream(filename, stream);
+  fclose(stream);
+  return ans;
+}


### PR DESCRIPTION
Instead of parsing the entire file in one go, we now parse command by command. 

One weird issue: Because mpc parses whitespace at the end of all tokens, this would hang on, eg, standard input, until the _next_ command started. To fix this, we now parse the command terminator '.' separately from the command itself. Then mpc can see that the previous command has ended and will return the AST instead of waiting to chomp the whitespace.
