### PR TITLE
Add record syntax

### DIFF
--- a/arvo-mode.el
+++ b/arvo-mode.el
@@ -58,7 +58,7 @@
   (save-excursion (search-forward s (line-end-position) 't)))
 
 (defconst arvo-font-lock-keywords
-  '(("\\<\\(def\\|axiom\\|import\\|print\\|check\\|simpl\\|data\\)\\>" . font-lock-keyword-face)
+  '(("\\<\\(def\\|axiom\\|import\\|print\\|check\\|simpl\\|data\\|record\\)\\>" . font-lock-keyword-face)
     ("\\<Type\\>" . font-lock-type-face)
     ("\\<def\\>" "\\<\\(\\w+\\)\\>" (position-of-string ":") nil (1 font-lock-function-name-face))
     ("\\\\" "\\<\\w+\\>" (let ((pd (position-of-string "."))

--- a/examples/good/record.arvo
+++ b/examples/good/record.arvo
@@ -1,0 +1,25 @@
+record unit := { }.
+check unit.
+check unit_intro.
+check unit_elim.
+
+record id (A : Type) := { id_out : A }.
+check id.
+check id_intro.
+check id_elim.
+check id_out.
+
+
+record prod (A : Type) (B : Type) := { fst : A ; snd : B }.
+check prod.
+check prod_intro.
+check prod_elim.
+check fst.
+check snd.
+
+record sigma (A : Type) (B : A -> Type) := { sig_fst : A; sig_snd : B sig_fst }.
+check sigma.
+check sigma_intro.
+check sigma_elim.
+check sig_fst.
+check sig_snd.

--- a/vernac.h
+++ b/vernac.h
@@ -10,6 +10,7 @@ typedef enum command_tag {
   CHECK,
   SIMPL,
   DATA,
+  RECORD,
   AXIOM,
   IMPORT
 } command_tag;
@@ -24,6 +25,10 @@ typedef struct command {
   int num_params;
   variable** param_names;
   term** param_types;
+  int num_fields;
+  variable** field_names;
+  term** field_types;
+
   term* indices;  // pi-type returning Type
 } command;
 
@@ -35,6 +40,7 @@ command *make_print(variable *t);
 command *make_check(term *t);
 command *make_simpl(term *t);
 command *make_data(variable* name, int num_constructors, int num_params);
+command *make_record(variable* name, int num_fields, int num_params);
 command *make_axiom(variable* name, term* ty);
 command *make_import(variable* name);
 


### PR DESCRIPTION
This lets you write things like 

```
record pair (A : Type) (B : Type) := { fst : A ; snd : B }.
```

and have the right thing happen. A constructor and field projections are automatically defined. In this case you would get `pair_intro : (A : Type) -> (B : Type) -> A -> B -> pair A B` and `fst` and `snd` with the expected types. 

Later fields are also allowed to depend on earlier ones by referring directly to the field name.

Recursive records are not allowed. 

See `examples/good/record.arvo` for more examples. 
